### PR TITLE
Support showing offsets of instrutions in src symbol

### DIFF
--- a/symrel_tracer_print.py
+++ b/symrel_tracer_print.py
@@ -37,7 +37,16 @@ def str_helper(self, color):
     second = sym_str
 
     if self.parent:
-        step_info = ' or '.join([self.sr.instructions[idx] for idx in self.insts])
+        inst_str_list = []
+        for inst in self.insts:
+            if isinstance(self.sr.instructions[inst], tuple):
+                # inst is wrapped with offset info
+                real_ind = self.sr.instructions[inst][0]
+                offset = self.sr.instructions[inst][1]
+                inst_str_list.append(f'{self.sr.instructions[real_ind]} at +{offset}')
+            else:
+                inst_str_list.append(self.sr.instructions[inst])
+        step_info = ' or '.join(inst_str_list)
 
         step = ''.join([c*len(step_info) for c in '─'])
         if self.forward == None: step = '<' + step + '>'


### PR DESCRIPTION
e.g.

```
# echo no_context | ./symrel.py -t get jumpers
                   jmp at +89
    [no_context] ┬<─────────── [mm_fault_error]
                 │
                 │ jmp at +1020
                 ├<───────────── [__do_page_fault]
                 │
                 │ jmp at +263
                 └<──────────── [__bad_area_nosemaphore]
```